### PR TITLE
Fixed failing test cases - delete_note and open_existing_node

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -22,11 +22,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install system dependencies (Ubuntu)
-      run: |
-        sudo apt update
-        sudo apt install -y libcairo2-dev pkg-config libglib2.0-dev libpixman-1-dev
-        sudo apt install -y libpango1.0-dev libpangocairo-1.0-0
-        sudo apt install -y python3-dev python3-pip python3-setuptools python3-wheel
+      run: sudo apt update && sudo apt install -y libcairo2-dev
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -21,6 +21,8 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install system dependencies (Ubuntu)
+      run: sudo apt update && sudo apt install -y libcairo2-dev
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -21,8 +21,6 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install system dependencies (Ubuntu)
-      run: sudo apt update && sudo apt install -y libcairo2-dev
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -22,7 +22,11 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install system dependencies (Ubuntu)
-      run: sudo apt update && sudo apt install -y libcairo2-dev
+      run: |
+        sudo apt update
+        sudo apt install -y libcairo2-dev pkg-config libglib2.0-dev libpixman-1-dev
+        sudo apt install -y libpango1.0-dev libpangocairo-1.0-0
+        sudo apt install -y python3-dev python3-pip python3-setuptools python3-wheel
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -14,6 +14,8 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install system dependencies (Ubuntu)
+      run: sudo apt update && sudo apt install -y libcairo2-dev
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/notes/tests/test_selenium_notes.py
+++ b/notes/tests/test_selenium_notes.py
@@ -39,6 +39,8 @@ class TestNote(LoginTest):
  
     def test_trash_note(self):
         self.driver.get(self.shared_data['new_note_url'])
+        self.driver.find_element(By.ID, 'settingsButton').click()
+        sleep(0.5) 
         self.driver.find_element(By.ID, 'deleteNoteButton').click()
         sleep(0.5)
         self.driver.find_element(By.ID, 'modalDeleteNoteButton').click()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pycairo<1.27.0
 asgiref==3.6.0
 Brotli==1.0.9
 Django==4.1.7


### PR DESCRIPTION
Both test cases - delete_note and open_existing_note- failed the Selenium test cases. 

Delete_note was failing because of the restructured note menu (with the AI tools button) and because of moving the delete note button under the settings button. 
Open_existing_note failed because of a buildup of undelete notes and couldn't not find the standard test note within the Window frame. 

Also modified django.yml and pylint.yml to include installs for cario (needed for a python package)